### PR TITLE
Unpins django-bootstrap to allow other versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'django-fontawesome==0.2.2',
-        'django-bootstrap3==4.11.0',
+        'django-bootstrap3',
     ],
     license='BSD License',
     description="A responsive front-end boilerplate designed for Wharton Django/Python apps.",


### PR DESCRIPTION
I worked on an Django 1.9 app which needs a newer version of django-bootstrap3 (7.0.1) which is not released yet. This project also requires django-base-theme which uninstalls my pinned version because this setup is pinned to a specific version. 

🐔 and 🍳  if you will. 

I'm happy to discuss the change with you or the project can work off of my pinned version as an interim solution until django-bootstrap3 catches up :)